### PR TITLE
Change subprocess function from run to getoutput

### DIFF
--- a/demucs/audio.py
+++ b/demucs/audio.py
@@ -14,11 +14,8 @@ from .utils import temp_filenames
 
 
 def _read_info(path):
-    process = sp.run(
-        ['ffprobe', str(path), '-print_format', 'json', '-show_format', '-show_streams'],
-        capture_output=True,
-        check=True)
-    return json.loads(process.stdout.decode('utf-8'))
+    stdout_data = sp.getoutput('ffprobe {} -print_format json -show_format -show_streams'.format(str(path)))
+    return json.loads(stdout_data[stdout_data.index('{\n'):])
 
 
 class AudioFile:

--- a/demucs/audio.py
+++ b/demucs/audio.py
@@ -14,8 +14,10 @@ from .utils import temp_filenames
 
 
 def _read_info(path):
-    stdout_data = sp.getoutput('ffprobe {} -print_format json -show_format -show_streams'.format(str(path)))
-    return json.loads(stdout_data[stdout_data.index('{\n'):])
+    stdout_data = sp.check_output(
+        ['ffprobe', str(path), '-print_format', 'json', '-show_format', '-show_streams']
+    )
+    return json.loads(stdout_data.decode('utf-8'))
 
 
 class AudioFile:


### PR DESCRIPTION
As I made an issue on #4 , sp.run is failed with 'capture_output' argument with python 3.6. 
So I changed function from run to getoutput that can run on both of python 3.6 and 3.7.