### PR TITLE
Fixed an issue when reading mono files

### DIFF
--- a/demucs/audio.py
+++ b/demucs/audio.py
@@ -130,9 +130,25 @@ class AudioFile:
                 wav = torch.from_numpy(wav)
                 wav = wav.view(-1, self.channels()).t()
                 if channels == 1:
+                    # Case 1:
+                    # The caller asked 1-channel audio, but the stream have multiple
+                    # channels, downmix all channels.
                     # We do mono convertion here as ffmpeg mess up the volume of mono output
                     # otherwise. See https://sound.stackexchange.com/a/42710.
                     wav = wav.mean(dim=0, keepdim=True)
+                elif self.channels() == 1 and channels != 1:
+                    # Case 2:
+                    # The caller asked for multiple channels, but the input file have
+                    # one single channel, replicate the audio over all channels.
+                    wav = wav.as_strided(size=(channels, wav.shape[1]), stride = (0,1));
+                elif self.channels() >= channels:
+                    # Case 3:
+                    # The caller asked for multiple channels, and the input file have
+                    # more channels than requested. In that case return the first channels.
+                    wav = wav[:channels,:];
+                else:
+                    # Case 4: What is a reasonable choice here?
+                    raise ValueException('The input file has less channels than requested')
                 if target_size is not None:
                     wav = wav[..., :target_size]
                 wavs.append(wav)


### PR DESCRIPTION
The previous implementation was returning an array of size (1, N) regardless of the value of channels.
This solves the following issue when running `python -m demucs.separate mono-input-file`:

File "C:\Users\bob\Documents\github\demucs\demucs\separate.py", line 135, in main
    sources = apply_model(model, wav, shifts=args.shifts, split=args.split, progress=True)
...
RuntimeError: Given groups=1, weight of size 100 2 8, expected input[1, 1, 451924] to have 2 channels, but got 1 channels instead