### PR TITLE
Allow custom sampling rate and number of audio channels at separation time.

### DIFF
--- a/demucs/__main__.py
+++ b/demucs/__main__.py
@@ -103,6 +103,7 @@ def main():
             sources=4,
             stride=args.conv_stride,
             upsample=args.upsample,
+            samplerate=args.samplerate
         )
     model.to(device)
     if args.show:
@@ -216,8 +217,7 @@ def main():
                                     device=device,
                                     rank=args.rank,
                                     split=args.split_valid,
-                                    world_size=args.world_size,
-                                    samplerate=args.samplerate)
+                                    world_size=args.world_size)
 
         duration = time.time() - begin
         if valid_loss < best_loss:
@@ -260,8 +260,7 @@ def main():
              save=args.save,
              split=args.split_valid,
              shifts=args.shifts,
-             workers=args.eval_workers,
-             samplerate=args.samplerate)
+             workers=args.eval_workers)
     model.to("cpu")
     save_model(model, args.models / f"{name}.th")
     if args.rank == 0:

--- a/demucs/__main__.py
+++ b/demucs/__main__.py
@@ -216,7 +216,8 @@ def main():
                                     device=device,
                                     rank=args.rank,
                                     split=args.split_valid,
-                                    world_size=args.world_size)
+                                    world_size=args.world_size,
+                                    samplerate=args.samplerate)
 
         duration = time.time() - begin
         if valid_loss < best_loss:
@@ -259,7 +260,8 @@ def main():
              save=args.save,
              split=args.split_valid,
              shifts=args.shifts,
-             workers=args.eval_workers)
+             workers=args.eval_workers,
+             samplerate=args.samplerate)
     model.to("cpu")
     save_model(model, args.models / f"{name}.th")
     if args.rank == 0:

--- a/demucs/model.py
+++ b/demucs/model.py
@@ -73,7 +73,8 @@ class Demucs(nn.Module):
                  stride=4,
                  growth=2.,
                  lstm_layers=2,
-                 context=3):
+                 context=3,
+                 samplerate=44100):
         """
         Args:
             sources (int): number of sources to separate
@@ -108,6 +109,7 @@ class Demucs(nn.Module):
         self.depth = depth
         self.upsample = upsample
         self.channels = channels
+        self.samplerate = samplerate
 
         self.encoder = nn.ModuleList()
         self.decoder = nn.ModuleList()

--- a/demucs/separate.py
+++ b/demucs/separate.py
@@ -79,7 +79,7 @@ def verify_file(target, sha256):
         sys.exit(1)
 
 
-def encode_mp3(wav, path, bitrate=320, verbose=False):
+def encode_mp3(wav, path, bitrate=320, samplerate=44100, channels=2, verbose=False):
     try:
         import lameenc
     except ImportError:
@@ -90,8 +90,8 @@ def encode_mp3(wav, path, bitrate=320, verbose=False):
         sys.exit(1)
     encoder = lameenc.Encoder()
     encoder.set_bit_rate(bitrate)
-    encoder.set_in_sample_rate(44100)
-    encoder.set_channels(2)
+    encoder.set_in_sample_rate(samplerate)
+    encoder.set_channels(channels)
     encoder.set_quality(2)  # 2-highest, 7-fastest
     if not verbose:
         encoder.silence()
@@ -161,6 +161,14 @@ def main():
                         default=320,
                         type=int,
                         help="Bitrate of converted mp3.")
+    parser.add_argument("--samplerate",
+                        default=44100,
+                        type=int,
+                        help="Sampling rate of trained model and input tracks.")
+    parser.add_argument("--audio_channels",
+                        default=2,
+                        type=int,
+                        help="Number of audio channels of trained model and input tracks.")
 
     args = parser.parse_args()
     name = args.name + ".th"
@@ -200,12 +208,12 @@ def main():
                 file=sys.stderr)
             continue
         print(f"Separating track {track}")
-        wav = AudioFile(track).read(streams=0, samplerate=44100, channels=2).to(args.device)
+        wav = AudioFile(track).read(streams=0, samplerate=args.samplerate, channels=args.audio_channels).to(args.device)
         # Round to nearest short integer for compatibility with how MusDB load audio with stempeg.
         wav = (wav * 2**15).round() / 2**15
         ref = wav.mean(0)
         wav = (wav - ref.mean()) / ref.std()
-        sources = apply_model(model, wav, shifts=args.shifts, split=args.split, progress=True)
+        sources = apply_model(model, wav, samplerate=args.samplerate, shifts=args.shifts, split=args.split, progress=True)
         sources = sources * ref.std() + ref.mean()
 
         track_folder = out / track.name.split(".")[0]
@@ -216,10 +224,10 @@ def main():
             source = source.cpu().transpose(0, 1).numpy()
             stem = str(track_folder / name)
             if args.mp3:
-                encode_mp3(source, stem + ".mp3", args.mp3_bitrate, verbose=args.verbose)
+                encode_mp3(source, stem + ".mp3", bitrate=args.mp3_bitrate, samplerate=args.samplerate, channels=args.audio_channels, verbose=args.verbose)
             else:
                 wavname = str(track_folder / f"{name}.wav")
-                wavfile.write(wavname, 44100, source)
+                wavfile.write(wavname, args.samplerate, source)
 
 
 if __name__ == "__main__":

--- a/demucs/test.py
+++ b/demucs/test.py
@@ -28,7 +28,8 @@ def evaluate(model,
              shifts=0,
              split=False,
              check=True,
-             world_size=1):
+             world_size=1,
+             samplerate=44100):
     """
     Evaluate model using museval. Run the model
     on a single GPU, the bottleneck being the call to museval.
@@ -60,7 +61,7 @@ def evaluate(model,
             ref = mix.mean(dim=0)  # mono mixture
             mix = (mix - ref.mean()) / ref.std()
 
-            estimates = apply_model(model, mix.to(device), shifts=shifts, split=split)
+            estimates = apply_model(model, mix.to(device), samplerate=samplerate, shifts=shifts, split=split)
             estimates = estimates * ref.std() + ref.mean()
 
             estimates = estimates.transpose(1, 2)

--- a/demucs/test.py
+++ b/demucs/test.py
@@ -28,8 +28,7 @@ def evaluate(model,
              shifts=0,
              split=False,
              check=True,
-             world_size=1,
-             samplerate=44100):
+             world_size=1):
     """
     Evaluate model using museval. Run the model
     on a single GPU, the bottleneck being the call to museval.
@@ -61,7 +60,7 @@ def evaluate(model,
             ref = mix.mean(dim=0)  # mono mixture
             mix = (mix - ref.mean()) / ref.std()
 
-            estimates = apply_model(model, mix.to(device), samplerate=samplerate, shifts=shifts, split=split)
+            estimates = apply_model(model, mix.to(device), shifts=shifts, split=split)
             estimates = estimates * ref.std() + ref.mean()
 
             estimates = estimates.transpose(1, 2)

--- a/demucs/train.py
+++ b/demucs/train.py
@@ -84,8 +84,7 @@ def validate_model(epoch,
                    rank=0,
                    world_size=1,
                    shifts=0,
-                   split=False,
-                   samplerate=44100):
+                   split=False):
     indexes = range(rank, len(dataset), world_size)
     tq = tqdm.tqdm(indexes,
                    ncols=120,
@@ -101,7 +100,7 @@ def validate_model(epoch,
         streams = streams.to(device)
         sources = streams[1:]
         mix = streams[0]
-        estimates = apply_model(model, mix, samplerate=samplerate, shifts=shifts, split=split)
+        estimates = apply_model(model, mix, shifts=shifts, split=split)
         loss = criterion(estimates, sources)
         current_loss += loss.item() / len(indexes)
         del estimates, streams, sources

--- a/demucs/train.py
+++ b/demucs/train.py
@@ -84,7 +84,8 @@ def validate_model(epoch,
                    rank=0,
                    world_size=1,
                    shifts=0,
-                   split=False):
+                   split=False,
+                   samplerate=44100):
     indexes = range(rank, len(dataset), world_size)
     tq = tqdm.tqdm(indexes,
                    ncols=120,
@@ -100,7 +101,7 @@ def validate_model(epoch,
         streams = streams.to(device)
         sources = streams[1:]
         mix = streams[0]
-        estimates = apply_model(model, mix, shifts=shifts, split=split)
+        estimates = apply_model(model, mix, samplerate=samplerate, shifts=shifts, split=split)
         loss = criterion(estimates, sources)
         current_loss += loss.item() / len(indexes)
         del estimates, streams, sources

--- a/demucs/utils.py
+++ b/demucs/utils.py
@@ -92,7 +92,7 @@ def human_seconds(seconds, display='.2f'):
     return f"{format(value, display)} {last}"
 
 
-def apply_model(model, mix, samplerate=44100, shifts=None, split=False, progress=False):
+def apply_model(model, mix, shifts=None, split=False, progress=False):
     """
     Apply model to a given mixture.
 
@@ -110,26 +110,26 @@ def apply_model(model, mix, samplerate=44100, shifts=None, split=False, progress
     device = mix.device
     if split:
         out = th.zeros(4, channels, length, device=device)
-        shift = samplerate * 10
+        shift = model.samplerate * 10
         offsets = range(0, length, shift)
         scale = 10
         if progress:
             offsets = tqdm.tqdm(offsets, unit_scale=scale, ncols=120, unit='seconds')
         for offset in offsets:
             chunk = mix[..., offset:offset + shift]
-            chunk_out = apply_model(model, chunk, samplerate=samplerate, shifts=shifts)
+            chunk_out = apply_model(model, chunk, shifts=shifts)
             out[..., offset:offset + shift] = chunk_out
             offset += shift
         return out
     elif shifts:
-        max_shift = int(samplerate / 2)
+        max_shift = int(model.samplerate / 2)
         mix = F.pad(mix, (max_shift, max_shift))
         offsets = list(range(max_shift))
         random.shuffle(offsets)
         out = 0
         for offset in offsets[:shifts]:
             shifted = mix[..., offset:offset + length + max_shift]
-            shifted_out = apply_model(model, shifted, samplerate=samplerate)
+            shifted_out = apply_model(model, shifted)
             out += shifted_out[..., max_shift - offset:max_shift - offset + length]
         out /= shifts
         return out


### PR DESCRIPTION
As a byproduct, the sampling rate is always passed to `utils.apply_model` in order for the random shifts and split segments to be calculated in seconds. 