### PR TITLE
Avoid a possibly unneeded cast for "device"

### DIFF
--- a/demucs/apply.py
+++ b/demucs/apply.py
@@ -164,8 +164,8 @@ def apply_model(model, mix, shifts=1, split=True,
         # We start from a triangle shaped weight, with maximal weight in the middle
         # of the segment. Then we normalize and take to the power `transition_power`.
         # Large values of transition power will lead to sharper transitions.
-        weight = th.cat([th.arange(1, segment // 2 + 1),
-                         th.arange(segment - segment // 2, 0, -1)]).to(device)
+        weight = th.cat([th.arange(1, segment // 2 + 1, device=device),
+                         th.arange(segment - segment // 2, 0, -1, device=device)])
         assert len(weight) == segment
         # If the overlap < 50%, this will translate to linear transition when
         # transition_power is 1.


### PR DESCRIPTION
It's more efficient to create the data directly into the proper "device", rather than casting it after we've done th.cat().

That's a very minor thing but I've noticed it while I was working on another code changes. Also note that I have no knowledge in ML at all, so if I'm wrong, please accept my apologies.