### PR TITLE
Fixing #240

### DIFF
--- a/demucs/apply.py
+++ b/demucs/apply.py
@@ -146,8 +146,8 @@ def apply_model(model, mix, shifts=1, split=True,
                 totals[k] += inst_weight    
             estimates += out
             
-        for k in range(estimates.shape[0]):
-            estimates[k] /= totals[k]
+        for k in range(estimates.shape[1]):
+            estimates[:, k, :, :] /= totals[k]
         return estimates
 
     assert transition_power >= 1, "transition_power < 1 leads to weird behavior."

--- a/demucs/apply.py
+++ b/demucs/apply.py
@@ -141,10 +141,11 @@ def apply_model(model, mix, shifts=1, split=True,
                 sub_model, mix,
                 shifts=shifts, split=split, overlap=overlap,
                 transition_power=transition_power, progress=progress)
-            for k in range(out.shape[0]):
-                out[k] *= weight[k]
-                totals[k] += weight[k]
+            for k, inst_weight in enumerate(weight):
+                out[:, k, :, :] *= inst_weight
+                totals[k] += inst_weight    
             estimates += out
+            
         for k in range(estimates.shape[0]):
             estimates[k] /= totals[k]
         return estimates


### PR DESCRIPTION
For the case of `mdx_extra`, the weights are always [1, 1, 1, 1]. If there are no other models, I think it'll be fine to simply overwrite this fix to the current version. But that's just me. 

Anyway, please feel free to merge or decline depending on how you want to fix. 