### PR TITLE
Always use CPU RAM for the whole WAV track and most temporary results

### DIFF
--- a/demucs/separate.py
+++ b/demucs/separate.py
@@ -112,18 +112,17 @@ def main():
                 file=sys.stderr)
             continue
         print(f"Separating track {track}")
-        wav = load_track(track, args.device, model.audio_channels, model.samplerate)
+        wav = load_track(track, "cpu", model.audio_channels, model.samplerate)
 
         ref = wav.mean(0)
         wav = (wav - ref.mean()) / ref.std()
-        sources = apply_model(model, wav[None], shifts=args.shifts, split=args.split,
+        sources = apply_model(model, wav[None], args.device, shifts=args.shifts, split=args.split,
                               overlap=args.overlap, progress=True)[0]
         sources = sources * ref.std() + ref.mean()
 
         track_folder = out / track.name.rsplit(".", 1)[0]
         track_folder.mkdir(exist_ok=True)
         for source, name in zip(sources, model.sources):
-            source = source.cpu()
             stem = str(track_folder / name)
             if args.mp3:
                 stem += ".mp3"


### PR DESCRIPTION
If CUDA is available, we use it only for the computational intensive
operations like the model apply. Small temporary results are still kept
in CUDA, in order to avoid unneeded transfer to CPU.

This approach lets us process arbitrary long tracks while requiring
GPU VRAM only for the model size. The MDX model takes about 1.3 GB
of GPU VRAM.

Processing a one hour audio track this way takes about 6% more time than
doing it purely in the GPU. It requires additional 25 GB of CPU RAM.

Without the current code changes, processing a one hour track is
not possible even with a GPU with 16 GB VRAM.