### PR TITLE
Add argument to change split chunk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ demucs -n mdx_q myfile.mp3
 demucs --two-stems=vocals myfile.mp3
 ```
 
-If you have a GPU, but you run out of memory, please use `--segment SEGMENT` to reduce length of each split. `SEGMENT` should be changed to a integer. Personally recommend not less than 10 (the bigger the number is, the more memory is required, but quality may increase). If this still cannot help, please add `-d cpu` to the command line. See the section hereafter for more details on the memory requirements for GPU acceleration.
+If you have a GPU, but you run out of memory, please use `--segment SEGMENT` to reduce length of each split. `SEGMENT` should be changed to a integer. Personally recommend not less than 10 (the bigger the number is, the more memory is required, but quality may increase). Create an environment variable `PYTORCH_NO_CUDA_MEMORY_CACHING=1` is also helpful. If this still cannot help, please add `-d cpu` to the command line. See the section hereafter for more details on the memory requirements for GPU acceleration.
 
 Separated tracks are stored in the `separated/MODEL_NAME/TRACK_NAME` folder. There you will find four stereo wav files sampled at 44.1 kHz: `drums.wav`, `bass.wav`,
 `other.wav`, `vocals.wav` (or `.mp3` if you used the `--mp3` option).
@@ -211,7 +211,7 @@ This will multiply by the same amount the RAM used so be careful!
 
 ### Memory requirements for GPU acceleration
 
-If you want to use GPU acceleration, you will need at least 3GB of RAM on your GPU for `demucs`. However, about 7GB of RAM will be required if you use the default arguments. Add `--segment SEGMENT` to change size of each split. If you only have 3GB memory, set SEGMENT to 8 (though quality may be worse if this argument is too small). 
+If you want to use GPU acceleration, you will need at least 3GB of RAM on your GPU for `demucs`. However, about 7GB of RAM will be required if you use the default arguments. Add `--segment SEGMENT` to change size of each split. If you only have 3GB memory, set SEGMENT to 8 (though quality may be worse if this argument is too small). Creating an environment variable `PYTORCH_NO_CUDA_MEMORY_CACHING=1` can help users with even smaller RAM such as 2GB (I separated a track that is 4 minutes but only 1.5GB is used), but this would make the separation slower. 
 
 If you do not have enough memory on your GPU, simply add `-d cpu` to the command line to use the CPU. With Demucs, processing time should be roughly equal to 1.5 times the duration of the track.
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ demucs -n mdx_q myfile.mp3
 demucs --two-stems=vocals myfile.mp3
 ```
 
-If you have a GPU, but you run out of memory, please add `-d cpu` to the command line. See the section hereafter for more details on the memory requirements for GPU acceleration.
+If you have a GPU, but you run out of memory, please use `--segment SEGMENT` to reduce length of each split. `SEGMENT` should be changed to a integer. Personally recommend not less than 10 (the bigger the number is, the more memory is required, but quality may increase). If this still cannot help, please add `-d cpu` to the command line. See the section hereafter for more details on the memory requirements for GPU acceleration.
 
 Separated tracks are stored in the `separated/MODEL_NAME/TRACK_NAME` folder. There you will find four stereo wav files sampled at 44.1 kHz: `drums.wav`, `bass.wav`,
 `other.wav`, `vocals.wav` (or `.mp3` if you used the `--mp3` option).
@@ -211,7 +211,9 @@ This will multiply by the same amount the RAM used so be careful!
 
 ### Memory requirements for GPU acceleration
 
-If you want to use GPU acceleration, you will need at least 8GB of RAM on your GPU for `demucs`. Sorry, the code for demucs is not super optimized for memory! If you do not have enough memory on your GPU, simply add `-d cpu` to the command line to use the CPU. With Demucs, processing time should be roughly equal to 1.5 times the duration of the track.
+If you want to use GPU acceleration, you will need at least 3GB of RAM on your GPU for `demucs`. However, about 7GB of RAM will be required if you use the default arguments. Add `--segment SEGMENT` to change size of each split. If you only have 3GB memory, set SEGMENT to 8 (though quality may be worse if this argument is too small). 
+
+If you do not have enough memory on your GPU, simply add `-d cpu` to the command line to use the CPU. With Demucs, processing time should be roughly equal to 1.5 times the duration of the track.
 
 
 ## Training Demucs

--- a/demucs/separate.py
+++ b/demucs/separate.py
@@ -83,7 +83,8 @@ def main():
                              help="Doesn't split audio in chunks. "
                              "This can use large amounts of memory.")
     split_group.add_argument("--segment", type=int,
-                             help="Set split size of each chunk. ")
+                             help="Set split size of each chunk. "
+                             "This can help save memory of graphic card. ")
     parser.add_argument("--two-stems",
                         dest="stem", metavar="STEM",
                         help="Only separate audio into {STEM} and no_{STEM}. ")
@@ -113,6 +114,9 @@ def main():
         model = get_model_from_args(args)
     except ModelLoadingError as error:
         fatal(error.args[0])
+
+    if args.segment is not None and args.segment < 8:
+        fatal('Segment must greater than 8. ')
 
     if isinstance(model, BagOfModels):
         print(f"Selected model is a bag of {len(model.models)} models. "

--- a/demucs/separate.py
+++ b/demucs/separate.py
@@ -80,8 +80,9 @@ def main():
                              action="store_false",
                              dest="split",
                              default=True,
-                             help="Doesn't split audio in chunks. This can use large amounts of memory.")
-    split_group.add_argument("--segment", type=int, 
+                             help="Doesn't split audio in chunks. "
+                             "This can use large amounts of memory.")
+    split_group.add_argument("--segment", type=int,
                              help="Set split size of each chunk. ")
     parser.add_argument("--two-stems",
                         dest="stem", metavar="STEM",

--- a/demucs/separate.py
+++ b/demucs/separate.py
@@ -75,12 +75,13 @@ def main():
                         default=0.25,
                         type=float,
                         help="Overlap between the splits.")
-    parser.add_argument("--no-split",
+    split_group = parser.add_mutually_exclusive_group()
+    split_group.add_argument("--no-split",
                         action="store_false",
                         dest="split",
                         default=True,
                         help="Doesn't split audio in chunks. This can use large amounts of memory.")
-    parser.add_argument("--segment", type=int, 
+    split_group.add_argument("--segment", type=int, 
                         help="Set split size of each chunk. ")
     parser.add_argument("--two-stems",
                         dest="stem", metavar="STEM",

--- a/demucs/separate.py
+++ b/demucs/separate.py
@@ -80,6 +80,8 @@ def main():
                         dest="split",
                         default=True,
                         help="Doesn't split audio in chunks. This can use large amounts of memory.")
+    parser.add_argument("--segment", type=int, 
+                        help="Set split size of each chunk. ")
     parser.add_argument("--two-stems",
                         dest="stem", metavar="STEM",
                         help="Only separate audio into {STEM} and no_{STEM}. ")
@@ -113,6 +115,13 @@ def main():
     if isinstance(model, BagOfModels):
         print(f"Selected model is a bag of {len(model.models)} models. "
               "You will see that many progress bars per track.")
+        if args.segment is not None:
+            for sub in model.models:
+                sub.segment = args.segment
+    else:
+        if args.segment is not None:
+            sub.segment = args.segment
+
     model.cpu()
     model.eval()
 

--- a/demucs/separate.py
+++ b/demucs/separate.py
@@ -77,12 +77,12 @@ def main():
                         help="Overlap between the splits.")
     split_group = parser.add_mutually_exclusive_group()
     split_group.add_argument("--no-split",
-                        action="store_false",
-                        dest="split",
-                        default=True,
-                        help="Doesn't split audio in chunks. This can use large amounts of memory.")
+                             action="store_false",
+                             dest="split",
+                             default=True,
+                             help="Doesn't split audio in chunks. This can use large amounts of memory.")
     split_group.add_argument("--segment", type=int, 
-                        help="Set split size of each chunk. ")
+                             help="Set split size of each chunk. ")
     parser.add_argument("--two-stems",
                         dest="stem", metavar="STEM",
                         help="Only separate audio into {STEM} and no_{STEM}. ")


### PR DESCRIPTION
The oringinal version can only split chunks into length that is set by the model. The new `--segment` argument can change least VRAM requirement to 2GB. 

Resolve #297
