### PR TITLE
Update introduction to Demucs-GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Integrated to [Huggingface Spaces](https://huggingface.co/spaces) with [Gradio](
 
 ### Graphical Interface
 
-@CarloGao4 has released a GUI for Demucs: [CarlGao4/Demucs-Gui](https://github.com/CarlGao4/Demucs-Gui). Downloads for Windows and macOS is available [here](https://github.com/CarlGao4/Demucs-Gui/releases)
+@CarloGao4 has released a GUI for Demucs: [CarlGao4/Demucs-Gui](https://github.com/CarlGao4/Demucs-Gui). Downloads for Windows and macOS is available [here](https://github.com/CarlGao4/Demucs-Gui/releases). 
 
 @Anjok07 is providing a self contained GUI in [UVR (Ultimate Vocal Remover)](https://github.com/facebookresearch/demucs/issues/334) that supports Demucs.
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Integrated to [Huggingface Spaces](https://huggingface.co/spaces) with [Gradio](
 
 ### Graphical Interface
 
-@CarloGao4 has released a first version of a GUI for Demucs: [CarlGao4/Demucs-Gui](https://github.com/CarlGao4/Demucs-Gui), although at the moment, binary release are not available. 
+@CarloGao4 has released a GUI for Demucs: [CarlGao4/Demucs-Gui](https://github.com/CarlGao4/Demucs-Gui). Downloads for Windows and macOS is available [here](https://github.com/CarlGao4/Demucs-Gui/releases)
 
 @Anjok07 is providing a self contained GUI in [UVR (Ultimate Vocal Remover)](https://github.com/facebookresearch/demucs/issues/334) that supports Demucs.
 


### PR DESCRIPTION
Downloads of Demucs-GUI for Windows and macOS is available [here](https://github.com/CarlGao4/Demucs-Gui/releases). 