### PR TITLE
minor device bug fixed with --no-split option

### DIFF
--- a/demucs/audio.py
+++ b/demucs/audio.py
@@ -210,6 +210,8 @@ def encode_mp3(wav, path, samplerate=44100, bitrate=320, verbose=False):
     encoder.set_quality(2)  # 2-highest, 7-fastest
     if not verbose:
         encoder.silence()
+    if 'cuda' in str(wav.device):
+        wav = wav.cpu()
     wav = wav.transpose(0, 1).numpy()
     mp3_data = encoder.encode(wav.tobytes())
     mp3_data += encoder.flush()


### PR DESCRIPTION
Hi!
Thank you for making this awesome work open-source!

When I run the command: `python3 -m demucs.separate --mp3 -v --no-split -n mdx_extra_q -d cuda -o out "Fallout New Vegas Radio  Lets Ride Into The Sunset Together.mp3" -o out_2`, I get the following error that can be easily reproduced:
![demucs_predict_no_split_bug](https://user-images.githubusercontent.com/42506819/178135901-b03889eb-f9a0-4455-ae14-2014c11b59bf.png)

However, the following commands that don't have the `--no-split` option run flawlessly and produce the outputs in appropriate folders:
```
python3 -m demucs.separate --mp3 -v -n mdx_extra_q -d cuda "Fallout New Vegas Radio  Lets Ride Into The Sunset Together.mp3" -o out
python3 -m demucs.separate --mp3 -v --shifts 10 -n mdx_extra_q -d cuda "Fallout New Vegas Radio  Lets Ride Into The Sunset Together.mp3" -o out_1
```

The bug was fixed with minor additions in the commits attached with this PR, however, it is possible that this bug might be part of another bug related to the `--no-split` option and I hope that it would be fixed soon. 
