### PR TITLE
fixed wrong parameter default for `pad1d`

### DIFF
--- a/demucs/hdemucs.py
+++ b/demucs/hdemucs.py
@@ -20,7 +20,7 @@ from .states import capture_init
 from .spec import spectro, ispectro
 
 
-def pad1d(x: torch.Tensor, paddings: tp.Tuple[int, int], mode: str = 'zero', value: float = 0.):
+def pad1d(x: torch.Tensor, paddings: tp.Tuple[int, int], mode: str = 'constant', value: float = 0.):
     """Tiny wrapper around F.pad, just to allow for reflect padding on small input.
     If this is the case, we insert extra 0 padding to the right before the reflection happen."""
     length = x.shape[-1]


### PR DESCRIPTION
Fixed the error "NotImplementedError: Unrecognised padding mode zero" due to the wrong default parameter 'zero' of `pad1d`.
see:
https://pytorch.org/docs/stable/generated/torch.nn.functional.pad.html?highlight=pad#torch.nn.functional.pad