### PR TITLE
Make it explicit in the readme that -j flag is CPU only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ The `--overlap` option controls the amount of overlap between prediction windows
 It can probably be reduced to 0.1 to improve a bit speed.
 
 
-The `-j` flag allow to specify a number of parallel jobs (e.g. `demucs -j 2 myfile.mp3`).
+The `-j` flag (CPU only) allows specifying a number of parallel jobs (e.g. `demucs -j 2 myfile.mp3`).
 This will multiply by the same amount the RAM used so be careful!
 
 ### Memory requirements for GPU acceleration


### PR DESCRIPTION
I guess it's somewhat implicit from the mention of RAM (as opposed to VRAM) but it confused me for a bit.

BTW, is there any easy way to parallelize processing on the GPU if you have say a 3090?