### PR TITLE
fix typo in docstring

### DIFF
--- a/demucs/audio.py
+++ b/demucs/audio.py
@@ -72,8 +72,7 @@ class AudioFile:
              duration=None,
              streams=slice(None),
              samplerate=None,
-             channels=None,
-             temp_folder=None):
+             channels=None):
         """
         Slightly more efficient implementation than stempeg,
         in particular, this will extract all stems at once
@@ -94,9 +93,6 @@ class AudioFile:
                 See https://sound.stackexchange.com/a/42710.
                 Our definition of mono is simply the average of the two channels. Any other
                 value will be ignored.
-            temp_folder (str or Path or None): temporary folder to use for decoding.
-
-
         """
         streams = np.array(range(len(self)))[streams]
         single = not isinstance(streams, np.ndarray)

--- a/demucs/demucs.py
+++ b/demucs/demucs.py
@@ -285,7 +285,7 @@ class Demucs(nn.Module):
             normalize (bool): normalizes the input audio on the fly, and scales back
                 the output by the same amount.
             resample (bool): upsample x2 the input and downsample /2 the output.
-            rescale (int): rescale initial weights of convolutions
+            rescale (float): rescale initial weights of convolutions
                 to get their standard deviation closer to `rescale`.
             samplerate (int): stored as meta information for easing
                 future evaluations of the model.


### PR DESCRIPTION
Fix data type of `rescale` in the docstring of class `Demucs`.