### PR TITLE
Add information about Neutone in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,10 @@ Integrated to [Huggingface Spaces](https://huggingface.co/spaces) with [Gradio](
 ### Other providers
 
 Audiostrip is providing free online separation with Demucs on their website [https://audiostrip.co.uk/](https://audiostrip.co.uk/).
+
 [MVSep](https://mvsep.com/) also provides free online separation, select `Demucs3 model B` for the best quality.
+
+[Neutone](https://neutone.space/) provides a realtime Demucs model in their free VST/AU plugin that can be used in your favorite DAW.
 
 
 ## Separating tracks


### PR DESCRIPTION
We just added a realtime implementation of a Demucs model within [Neutone](https://neutone.space/) in the latest release and I thought it would be a good idea to add it next to the other projects out there that provide Demucs models.

Let me know if this makes sense or any changes are needed!