### PR TITLE
Use mps by default if available

### DIFF
--- a/demucs/separate.py
+++ b/demucs/separate.py
@@ -41,7 +41,7 @@ def get_parser():
                         'Default is "{track}/{stem}.{ext}".')
     parser.add_argument("-d",
                         "--device",
-                        default="cuda" if th.cuda.is_available() else "cpu",
+                        default="cuda" if th.cuda.is_available() else "mps" if th.backends.mps.is_available() else "cpu",
                         help="Device to use, default is cuda if available else cpu")
     parser.add_argument("--shifts",
                         default=1,

--- a/demucs/separate.py
+++ b/demucs/separate.py
@@ -41,7 +41,13 @@ def get_parser():
                         'Default is "{track}/{stem}.{ext}".')
     parser.add_argument("-d",
                         "--device",
-                        default="cuda" if th.cuda.is_available() else "mps" if th.backends.mps.is_available() else "cpu",
+                        default=(
+                            "cuda"
+                            if th.cuda.is_available()
+                            else "mps"
+                            if th.backends.mps.is_available()
+                            else "cpu"
+                        ),
                         help="Device to use, default is cuda if available else cpu")
     parser.add_argument("--shifts",
                         default=1,


### PR DESCRIPTION
Use Apple Silicon's Metal Performance Shaders if available. This can already be done using "-d mps" but changing this configuration makes it available by default. In my testing this makes source separation about 8x faster on an M2 MBP.