### PR TITLE
Bug fix for repitching & tempo automix errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If you have anaconda installed, you can run from the root of this repository:
 conda env update -f environment-cpu.yml  # if you don't have GPUs
 conda env update -f environment-cuda.yml # if you have GPUs
 conda activate demucs
-pip install -e .
+pip install -e .[dev]
 ```
 
 This will create a `demucs` environment with all the dependencies installed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ torchaudio>=0.8,<2.1
 tqdm
 treetable
 soundfile>=0.10.3;sys_platform=="win32"
-librosa @ git+https://github.com/librosa/librosa.git@c0266e4
+librosa @ git+https://github.com/librosa/librosa.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ torchaudio>=0.8,<2.1
 tqdm
 treetable
 soundfile>=0.10.3;sys_platform=="win32"
+librosa @ git+https://github.com/librosa/librosa.git@c0266e4

--- a/tools/automix.py
+++ b/tools/automix.py
@@ -210,7 +210,7 @@ def get_part(spec, source, dt, dp):
         if isinstance(dt, np.ndarray) and dt.size == 1:
             dt = float(dt.item())  # Convert numpy array to Python scalar
         # Convert tempo change from relative change (e.g., -0.12 for 88%) to percentage change expected by `repitch`
-        tempo_percentage_change = dt * 100  # Convert to percentage (e.g., -12 for 88% speed)
+        tempo_percentage_change = dt * 100  # Convert to percentage
         # Apply pitch and tempo changes
         wav = repitch(wav, dp, tempo_percentage_change, voice=source == 3, samplerate=SR)
         # Adjust onsets according to new tempo

--- a/tools/automix.py
+++ b/tools/automix.py
@@ -205,11 +205,17 @@ def find_candidate(spec_ref, catalog, pitch_match=True):
 def get_part(spec, source, dt, dp):
     """Apply given delta of tempo and delta of pitch to a stem."""
     wav = spec.track[source]
-    if dt or dp:
-        wav = repitch(wav, dp, dt * 100, samplerate=SR, voice=source == 3)
+    if dt != 0 or dp != 0:  # Check if there's any change to apply
+        # Ensure 'dt' is a scalar if it's an array
+        if isinstance(dt, np.ndarray) and dt.size == 1:
+            dt = float(dt.item())  # Convert numpy array to Python scalar
+        # Convert tempo change from relative change (e.g., -0.12 for 88%) to percentage change expected by `repitch`
+        tempo_percentage_change = dt * 100  # Convert to percentage (e.g., -12 for 88% speed)
+        # Apply pitch and tempo changes
+        wav = repitch(wav, dp, tempo_percentage_change, voice=source == 3, samplerate=SR)
+        # Adjust onsets according to new tempo
         spec = spec._replace(onsets=spec.onsets / (1 + dt))
     return wav, spec
-
 
 def build_track(ref_index, catalog):
     """Given the reference track index and a catalog of track, builds


### PR DESCRIPTION
Fix for repitching `TypeError: unsupported format string passed to numpy.ndarray.__format__` error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/ubuntu/demucs/tools/automix.py", line 343, in <module>
    main()
  File "/home/ubuntu/demucs/tools/automix.py", line 327, in main
    track, origs = build_track(index, catalog)
  File "/home/ubuntu/demucs/tools/automix.py", line 245, in build_track
    wav, spec = get_part(spec, src, dt, dp)
  File "/home/ubuntu/demucs/tools/automix.py", line 209, in get_part
    wav = repitch(wav, dp, dt * 100, samplerate=SR, voice=source == 3)
  File "/home/ubuntu/demucs/demucs/repitch.py", line 74, in repitch
    f"-tempo={tempo:.6f}",
TypeError: unsupported format string passed to numpy.ndarray.__format__
```
and fix for `AttributeError: module 'scipy.signal' has no attribute 'hann'` :
```
concurrent.futures.process._RemoteTraceback:
"""
Traceback (most recent call last):
  File "/usr/lib/python3.10/concurrent/futures/process.py", line 246, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/home/ubuntu/demucs/tools/automix.py", line 81, in analyse_track
    tempo, events = beat_track(y=drums.numpy(), units='time', sr=SR)
  File "/home/ubuntu/demucs/.venv/lib/python3.10/site-packages/librosa/beat.py", line 185, in beat_track
    beats = __beat_tracker(onset_envelope, bpm, float(sr) / hop_length, tightness, trim)
  File "/home/ubuntu/demucs/.venv/lib/python3.10/site-packages/librosa/beat.py", line 433, in __beat_tracker
    beats = __trim_beats(localscore, beats, trim)
  File "/home/ubuntu/demucs/.venv/lib/python3.10/site-packages/librosa/beat.py", line 507, in __trim_beats
    smooth_boe = scipy.signal.convolve(localscore[beats], scipy.signal.hann(5), "same")
AttributeError: module 'scipy.signal' has no attribute 'hann'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/ubuntu/demucs/tools/automix.py", line 343, in <module>
    main()
  File "/home/ubuntu/demucs/tools/automix.py", line 312, in main
    spec, track = pending.result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 458, in result
    return self.__get_result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
AttributeError: module 'scipy.signal' has no attribute 'hann'
```

## Explanation of code changes:
 Conditional Application:
The check `(dt != 0 or dp != 0)` ensures that `repitch` is only called if there is a change to be made, saving computational resources if the audio is to remain unaltered.

Type and Size Validation for `dt`:
It ensures that dt is a scalar by checking its type and size, which is crucial for correct format string usage in the `repitch` function's command construction.

Percentage Conversion:
The `tempo_percentage_change` calculation transforms `dt` from a decimal representation (e.g., `-0.12` for a tempo slowing to 88% of the original) into the format expected by the `repitch` function (e.g., `-12` to represent the same).

Application of Changes:
Calls `repitch` with the correct parameters, including checking if the current track is the voice track (assumed to be at index 3).

Onset Adjustment:
Adjusts the `onsets` of the `spec` to account for the new tempo. The onsets must be scaled by the reciprocal of `(1 + dt)` because a negative `dt` implies a reduction in speed (and hence longer duration between onsets).